### PR TITLE
feat(calendar): show tasks and meetings

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,6 +242,19 @@
             box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -2px rgba(0, 0, 0, 0.05);
         }
 
+        /* Contenedores para gráficos para evitar desbordes */
+        .chart-container {
+            position: relative;
+        }
+
+        .chart-container.large {
+            height: 300px;
+        }
+
+        .chart-container.small {
+            height: 200px;
+        }
+
         .btn {
             transition: all 0.2s ease;
         }
@@ -1793,25 +1806,33 @@
                         <div class="lg:col-span-2">
                             <div class="card p-6">
                                 <h3 class="text-sm font-medium text-gray-700 mb-4">Evolución de Tareas</h3>
-                                <canvas id="tasks-trend-chart" height="300"></canvas>
+                                <div class="chart-container large">
+                                    <canvas id="tasks-trend-chart"></canvas>
+                                </div>
                             </div>
 
                             <div class="card p-6 mt-6">
                                 <h3 class="text-sm font-medium text-gray-700 mb-4">Distribución por Tipo de
                                     Levantamiento</h3>
-                                <canvas id="inspections-type-chart" height="300"></canvas>
+                                <div class="chart-container large">
+                                    <canvas id="inspections-type-chart"></canvas>
+                                </div>
                             </div>
                         </div>
 
                         <div class="lg:col-span-1">
                             <div class="card p-6">
                                 <h3 class="text-sm font-medium text-gray-700 mb-4">Distribución de Tareas</h3>
-                                <canvas id="tasks-status-chart" height="200"></canvas>
+                                <div class="chart-container small">
+                                    <canvas id="tasks-status-chart"></canvas>
+                                </div>
                             </div>
 
                             <div class="card p-6 mt-6">
                                 <h3 class="text-sm font-medium text-gray-700 mb-4">Productividad por Terminal</h3>
-                                <canvas id="terminal-productivity-chart" height="200"></canvas>
+                                <div class="chart-container small">
+                                    <canvas id="terminal-productivity-chart"></canvas>
+                                </div>
                             </div>
 
                             <div class="card p-6 mt-6">
@@ -5435,61 +5456,73 @@ async function handleTaskFormSubmit(e) {
                     {
                         events: async function (info, successCallback, failureCallback) {
                             try {
-                                // Cargar tareas y reuniones
-                                const tasks = await fetchTasks();
-                                const meetings = await fetchMeetings();
-
-                                // Determinar qué mostrar según el botón activo
                                 const showTasks = document.querySelector('#task-calendar-view').classList.contains('bg-primary-600');
                                 const showMeetings = document.querySelector('#meeting-calendar-view').classList.contains('bg-primary-600');
 
+                                // Cargar tareas y reuniones en paralelo
+                                const [tasks, meetings] = await Promise.all([fetchTasks(), fetchMeetings()]);
+
                                 let events = [];
 
-                                // Convertir tareas a eventos
+                                // Convertir tareas a eventos (omitimos completadas)
                                 if (showTasks) {
-                                    const allTasks = [
-                                        ...tasks.assigned,
-                                        ...tasks.created.filter(task => !tasks.assigned.some(t => t.id === task.id))
-                                    ];
+                                    const allTasks = (tasks.all && tasks.all.length)
+                                        ? tasks.all
+                                        : [
+                                            ...tasks.assigned,
+                                            ...tasks.created.filter(task => !tasks.assigned.some(t => t.id === task.id))
+                                        ];
 
-                                    events = events.concat(allTasks.map(task => ({
-                                        id: `task-${task.id}`,
-                                        title: task.title,
-                                        start: task.due_date || task.created_at,
-                                        backgroundColor: getStatusColor(task.status),
-                                        borderColor: getStatusColor(task.status),
-                                        textColor: '#ffffff',
-                                        extendedProps: {
-                                            type: 'task',
-                                            description: task.description,
-                                            status: task.status,
-                                            creator: task.creator ? task.creator.nombre_completo : 'Desconocido'
-                                        }
-                                    })));
+                                    events = events.concat(
+                                        allTasks
+                                            .filter(task => task.status !== 'Completada')
+                                            .map(task => ({
+                                                id: `task-${task.id}`,
+                                                title: task.title,
+                                                start: task.due_date || task.created_at,
+                                                backgroundColor: getStatusColor(task.status),
+                                                borderColor: getStatusColor(task.status),
+                                                textColor: '#ffffff',
+                                                extendedProps: {
+                                                    type: 'task',
+                                                    description: task.description,
+                                                    status: task.status,
+                                                    creator: task.creator ? task.creator.nombre_completo : 'Desconocido'
+                                                }
+                                            }))
+                                    );
                                 }
 
-                                // Convertir reuniones a eventos
+                                // Convertir reuniones a eventos (solo próximas si están disponibles)
                                 if (showMeetings) {
-                                    const allMeetings = [
-                                        ...meetings.upcoming,
-                                        ...meetings.past
-                                    ];
+                                    const meetingList = (meetings.all && meetings.all.length)
+                                        ? meetings.all
+                                        : [...meetings.upcoming, ...meetings.past];
 
-                                    events = events.concat(allMeetings.map(meeting => ({
-                                        id: `meeting-${meeting.id}`,
-                                        title: meeting.title,
-                                        start: `${meeting.date}T${meeting.time}`,
-                                        end: meeting.duration ? new Date(new Date(`${meeting.date}T${meeting.time}`).getTime() + meeting.duration * 60000).toISOString() : undefined,
-                                        backgroundColor: '#f59e0b',
-                                        borderColor: '#f59e0b',
-                                        textColor: '#ffffff',
-                                        extendedProps: {
-                                            type: 'meeting',
-                                            description: meeting.description,
-                                            location: meeting.location,
-                                            creator: meeting.creator ? meeting.creator.nombre_completo : 'Desconocido'
-                                        }
-                                    })));
+                                    events = events.concat(
+                                        meetingList.map(meeting => {
+                                            const start = `${meeting.date}T${meeting.time}`;
+                                            const end = meeting.duration
+                                                ? new Date(new Date(start).getTime() + meeting.duration * 60000).toISOString()
+                                                : undefined;
+
+                                            return {
+                                                id: `meeting-${meeting.id}`,
+                                                title: meeting.title,
+                                                start,
+                                                end,
+                                                backgroundColor: '#f59e0b',
+                                                borderColor: '#f59e0b',
+                                                textColor: '#ffffff',
+                                                extendedProps: {
+                                                    type: 'meeting',
+                                                    description: meeting.description,
+                                                    location: meeting.location,
+                                                    creator: meeting.creator ? meeting.creator.nombre_completo : 'Desconocido'
+                                                }
+                                            };
+                                        })
+                                    );
                                 }
 
                                 successCallback(events);
@@ -7512,6 +7545,9 @@ async function handleTaskFormSubmit(e) {
                 document.getElementById('report-completed-tasks').textContent = completedTasks;
                 document.getElementById('report-in-progress-tasks').textContent = inProgressTasks;
                 document.getElementById('report-inspections').textContent = totalInspections;
+
+                // Esperar al siguiente ciclo de renderizado para asegurar tamaños correctos
+                await new Promise(requestAnimationFrame);
 
                 // Renderizar gráficos
                 renderTasksStatusChart(tasks.all);


### PR DESCRIPTION
## Summary
- load tasks and meetings concurrently for calendar
- include tasks in progress and all meetings in event feed
- stabilize report charts with fixed containers and layout wait

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894f68c886c832d88c124f26be8e36b