### PR TITLE
Refactor app wrapper and streamline responsive styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -435,10 +435,15 @@
         }
         
         /* Utilities for showing/hiding content */
-        .auth-no .app-content {
+        #app {
             display: none;
         }
-        
+
+        .auth-yes #app {
+            display: flex;
+            flex-direction: column;
+        }
+
         .auth-yes .auth-screen {
             display: none;
         }
@@ -454,6 +459,8 @@
             border-bottom: 1px solid var(--border);
             position: sticky;
             top: 0;
+            left: 0;
+            width: 100%;
             z-index: var(--z-sticky);
             display: flex;
             align-items: center;
@@ -673,17 +680,18 @@
         .app-content {
             display: flex;
             flex: 1;
+            flex-direction: row-reverse;
         }
         
         /* Sidebar */
         .sidebar {
     width: var(--sidebar-width);
     background-color: var(--panel-bg);
-    border-right: 1px solid var(--border);
+    border-left: 1px solid var(--border);
     height: calc(100vh - var(--header-height));
     position: fixed;
     top: var(--header-height);
-    right: 0; /* Posicionar en el lado derecho */
+    right: 0;
     z-index: 90;
     transition: width 0.3s ease, transform 0.3s ease;
     display: flex;
@@ -737,13 +745,13 @@
 .sidebar-nav-item.active::before {
     content: "";
     position: absolute;
-    left: 0;
+    right: 0;
     top: 50%;
     transform: translateY(-50%);
     width: 3px;
     height: 20px;
     background-color: var(--primary);
-    border-radius: 0 2px 2px 0;
+    border-radius: 2px 0 0 2px;
 }
 
 .sidebar-nav-item i {
@@ -757,35 +765,25 @@
     font-weight: 500;
 }
 
-/* Área principal de contenido */
+/* Main Content */
 .main {
     flex: 1;
     padding: 20px;
     margin-right: var(--sidebar-width); /* Espacio para el sidebar derecho */
 }
 
-/* Media queries para dispositivos móviles */
 @media (max-width: 768px) {
     .sidebar {
         transform: translateX(100%);
         box-shadow: -2px 0 10px rgba(0, 0, 0, 0.1);
     }
-    
+
     .sidebar.expanded {
         transform: translateX(0);
     }
-    
     .main {
         margin-right: 0;
     }
-}
-
-
-        /* Main Content */
-        .main {
-    flex: 1;
-    padding: 20px;
-    margin-right: var(--sidebar-width); /* Espacio para el sidebar derecho */
 }
         
         .page-header {
@@ -1687,7 +1685,13 @@
             font-size: var(--font-size-xs);
             font-weight: 500;
         }
-        
+
+        @media (max-width: 768px) {
+            .mobile-nav {
+                display: block;
+            }
+        }
+
         /* Dark Mode Enhanced Futuristic Styles */
         .dark-mode .fc-h-event {
             background-color: var(--primary);
@@ -1816,23 +1820,6 @@
         }
         
         @media (max-width: 768px) {
-            .sidebar {
-        transform: translateX(100%);
-        box-shadow: -2px 0 10px rgba(0, 0, 0, 0.1);
-    }
-
-    .sidebar.expanded {
-        transform: translateX(0);
-    }
-            
-            .mobile-nav {
-                display: block;
-            }
-            
-            main {
-        margin-right: 0;
-    }
-            
             .cards-grid {
                 grid-template-columns: 1fr;
                 gap: 16px;
@@ -1866,16 +1853,16 @@
                 top: 16px;
                 right: 16px;
             }
-            
+
             .auth-card {
                 padding: 24px;
             }
-            
+
             .stat-card-value {
                 font-size: 24px;
             }
         }
-        
+
         @media (max-width: 576px) {
             .header-actions {
                 gap: 2px;
@@ -1947,7 +1934,7 @@
     </div>
     
     <!-- Main Application -->
-    <div class="app-content">
+    <div id="app" class="app">
         <!-- Header -->
         <header class="app-header">
             <button id="sidebar-toggle" class="header-toggle">
@@ -2193,7 +2180,7 @@
                 </div>
                 
                 <!-- Tareas View -->
-                <div id="view-tareas" class="view hidden">
+                <div id="view-tareas" class="view">
                     <div class="page-header">
                         <h1 class="page-title">Gestión de Tareas</h1>
                         <div class="page-actions">
@@ -2227,7 +2214,7 @@
                 </div>
                 
                 <!-- Levantamientos View -->
-                <div id="view-levantamientos" class="view hidden">
+                <div id="view-levantamientos" class="view">
                     <div class="page-header">
                         <h1 class="page-title">Levantamientos</h1>
                         <div class="page-actions">
@@ -2258,7 +2245,7 @@
                 </div>
                 
                 <!-- Reuniones View -->
-                <div id="view-reuniones" class="view hidden">
+                <div id="view-reuniones" class="view">
                     <div class="page-header">
                         <h1 class="page-title">Reuniones</h1>
                         <div class="page-actions">
@@ -2280,7 +2267,7 @@
                 </div>
                 
                 <!-- Calendario View -->
-                <div id="view-calendario" class="view hidden">
+                <div id="view-calendario" class="view">
                     <div class="page-header">
                         <h1 class="page-title">Calendario</h1>
                         <div class="page-actions">
@@ -2297,7 +2284,7 @@
                 </div>
                 
                 <!-- Informes View -->
-                <div id="view-informes" class="view hidden">
+                <div id="view-informes" class="view">
                     <div class="page-header">
                         <h1 class="page-title">Informes y Estadísticas</h1>
                     </div>
@@ -2336,7 +2323,7 @@
                 </div>
                 
                 <!-- Usuarios View -->
-                <div id="view-usuarios" class="view hidden">
+                <div id="view-usuarios" class="view">
                     <div class="page-header">
                         <h1 class="page-title">Gestión de Personal</h1>
                     </div>


### PR DESCRIPTION
## Summary
- Wrap application in `#app` to separate header from content and control visibility via auth classes
- Consolidate responsive rules so sidebar toggles and main content spacing behave correctly on mobile
- Render sidebar on the right and shift active indicators accordingly
- Ensure mobile navigation bar is visible on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d7c56b3dc832dbcb8a2b8ef59f17e