### PR TITLE
Ensure sidebar stays on the right

### DIFF
--- a/index.html
+++ b/index.html
@@ -680,18 +680,18 @@
         .app-content {
             display: flex;
             flex: 1;
-            flex-direction: row-reverse;
         }
-        
+
         /* Sidebar */
         .sidebar {
-    width: var(--sidebar-width);
-    background-color: var(--panel-bg);
-    border-left: 1px solid var(--border);
-    height: calc(100vh - var(--header-height));
     position: fixed;
     top: var(--header-height);
     right: 0;
+    left: auto;
+    height: calc(100vh - var(--header-height));
+    width: var(--sidebar-width);
+    background-color: var(--panel-bg);
+    border-left: 1px solid var(--border);
     z-index: 90;
     transition: width 0.3s ease, transform 0.3s ease;
     display: flex;
@@ -745,7 +745,7 @@
 .sidebar-nav-item.active::before {
     content: "";
     position: absolute;
-    right: 0;
+    right: 0; /* Align indicator to inner right edge */
     top: 50%;
     transform: translateY(-50%);
     width: 3px;
@@ -769,7 +769,14 @@
 .main {
     flex: 1;
     padding: 20px;
-    margin-right: var(--sidebar-width); /* Espacio para el sidebar derecho */
+    margin-right: var(--sidebar-width);
+    margin-left: 0;
+}
+
+@media (max-width: 1024px) {
+    .main {
+        margin-right: 0;
+    }
 }
 
 @media (max-width: 768px) {
@@ -782,17 +789,21 @@
         transform: translateX(0);
     }
 
-
-
     .mobile-nav {
         display: block;
     }
-
-
-    .main {
-        margin-right: 0;
-    }
 }
+
+        .chart-box {
+            position: relative;
+            width: 100%;
+            height: 320px;
+        }
+
+        .chart-box > canvas {
+            position: absolute;
+            inset: 0;
+        }
         
         .page-header {
             display: flex;
@@ -923,7 +934,13 @@
             grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
             gap: 20px;
             margin-bottom: 20px;
+            /* evita que los gráficos se estiren sin tope en pantallas muy anchas */
+            max-width: 1400px;
+            margin-inline: auto;
         }
+
+        /* Limita altura de los charts para evitar “crecimiento” vertical */
+        .card canvas { max-height: 340px; }
         
         .card-header {
             display: flex;
@@ -1771,48 +1788,6 @@
             background: rgba(59, 130, 246, 0.6);
         }
         
-        /* Responsive Styles */
-        @media (max-width: 1200px) {
-            .sidebar {
-                width: var(--sidebar-collapsed-width);
-            }
-            
-            .sidebar-nav-text {
-                display: none;
-            }
-            
-            .sidebar-nav-item {
-                justify-content: center;
-                padding: 10px;
-            }
-            
-            .sidebar-heading {
-                text-align: center;
-                padding: 0;
-            }
-            
-            .sidebar.expanded {
-                position: fixed;
-                width: var(--sidebar-width);
-                box-shadow: var(--shadow-lg);
-                z-index: var(--z-fixed);
-            }
-            
-            .sidebar.expanded .sidebar-nav-text {
-                display: block;
-            }
-            
-            .sidebar.expanded .sidebar-nav-item {
-                justify-content: flex-start;
-                padding: 10px 12px;
-            }
-            
-            .sidebar.expanded .sidebar-heading {
-                text-align: left;
-                padding: 0 10px;
-            }
-        }
-        
         @media (max-width: 992px) {
             .cards-grid {
                 grid-template-columns: repeat(2, 1fr);
@@ -2302,14 +2277,14 @@
                             <div class="card-header">
                                 <h2 class="card-title">Distribución de Tareas</h2>
                             </div>
-                            <canvas id="chart1" height="250"></canvas>
+                            <div class="chart-box"><canvas id="chart1"></canvas></div>
                         </div>
                         
                         <div class="card">
                             <div class="card-header">
                                 <h2 class="card-title">Evolución Semanal</h2>
                             </div>
-                            <canvas id="chart2" height="250"></canvas>
+                            <div class="chart-box"><canvas id="chart2"></canvas></div>
                         </div>
                     </div>
                     
@@ -2795,12 +2770,38 @@
             }
         }
         
+        // Helpers de permisos
         function canManage() {
-            return ["supervisor_admin", "jefe_terminal", "supervisor"].includes(me.role);
+            // Solo estos dos roles pueden crear/editar/posponer/añadir personal
+            return me && ['supervisor_admin','jefe_terminal'].includes(me.role);
         }
-        
         function canCreateUsers() {
-            return me.role === "supervisor_admin";
+            return me && me.role === 'supervisor_admin';
+        }
+
+        // Aplica la visibilidad de la UI según el rol
+        function applyRoleUI() {
+            const manage = canManage();
+            const canUsers = canCreateUsers();
+            const hide = sel => { const el = document.querySelector(sel); if (el) el.classList.add('hidden'); };
+            const show = sel => { const el = document.querySelector(sel); if (el) el.classList.remove('hidden'); };
+
+            // Botones de creación (dashboard/listas/modales)
+            ['#btn-new-task', '#btn-new-task-2', '#btn-new-meeting', '#btn-new-meeting-2', '#btn-new-lev']
+              .forEach(sel => manage ? show(sel) : hide(sel));
+
+            // Acciones de modales de reunión/tarea
+            ['#btn-save-nt', '#btn-save-nm', '#btn-save-em', '#btn-pospone-em']
+              .forEach(sel => { if (!manage) hide(sel); });
+
+            // Módulo de usuarios
+            if (!canUsers) hide('#btn-usuarios'); else show('#btn-usuarios');
+
+            // Si ya hay listas renderizadas, oculta botones de editar que hayan quedado
+            if (!manage) {
+                document.querySelectorAll('.btn-edit-task,.btn-edit-meeting,[onclick^="openEditMeeting("]')
+                  .forEach(el => el.classList.add('hidden'));
+            }
         }
         
 // JavaScript para la navegación del sidebar
@@ -2938,22 +2939,22 @@ window.toggleSidebar = toggleSidebar;
         function enterApp() {
             document.body.classList.remove("auth-no");
             document.body.classList.add("auth-yes");
-            
+
             // Update UI with user info
             qs("#ui-name").textContent = me.full_name;
             qs("#ui-role").textContent = me.role;
             qs("#ui-avatar").textContent = initials(me.full_name);
-            
-            // Show admin features if applicable
-            if (canCreateUsers()) qs("#btn-usuarios").classList.remove("hidden");
-            
+
+            // En cuanto tenemos el rol del usuario, aplicamos permisos en la UI
+            applyRoleUI();
+
             // Initialize app data and features
             initRealtime();
             loadUsers().then(() => {
                 populateSelectors();
                 refreshAll();
                 overdueScan();
-                
+
                 // Welcome toast
                 setTimeout(() => {
                     toast(`Bienvenido al sistema, ${me.full_name}`, "ok");
@@ -4083,10 +4084,11 @@ async function renderMeetings() {
                     ` : ''}
                 </div>
                 <div class="meeting-item-actions">
-                    <button class="btn btn-sm btn-primary" onclick="openEditMeeting('${meeting.id}')">
+                    ${canManage() ? `
+                    <button class="btn btn-sm btn-primary btn-edit-meeting" onclick="openEditMeeting('${meeting.id}')">
                         <i class="fas fa-edit"></i>
                         <span>Editar</span>
-                    </button>
+                    </button>` : ``}
                 </div>
             `;
             
@@ -4107,16 +4109,19 @@ async function renderMeetings() {
                         </span>
                     </div>
                 </div>
-                <button class="btn btn-sm btn-primary" onclick="openEditMeeting('${meeting.id}')">
+                ${canManage() ? `
+                <button class="btn btn-sm btn-primary btn-edit-meeting" onclick="openEditMeeting('${meeting.id}')">
                     <i class="fas fa-edit"></i>
                     <span>Editar</span>
-                </button>
+                </button>` : ``}
             `;
             
             meetingsContainer.appendChild(meetingItem);
             dashboardMeetingsContainer.appendChild(dashboardItem);
         });
-        
+
+        // Si hay otra plantilla similar (por ejemplo en el dashboard), aplicar la misma condición
+
     } catch (err) {
         console.error("Error rendering meetings:", err);
         toast("Error al cargar reuniones", "bad");
@@ -4124,6 +4129,7 @@ async function renderMeetings() {
 }
 
 async function openEditMeeting(id) {
+    if (!canManage()) { toast("Sin permiso", "warn"); return; }
     editMeetingId = id;
     
     try {
@@ -4167,6 +4173,7 @@ async function openEditMeeting(id) {
 }
 
 async function saveEditMeeting() {
+    if (!canManage()) { toast("Sin permisos para editar reuniones", "bad"); return; }
     if (!editMeetingId) return;
     
     const title = qs("#em-title").value.trim();
@@ -4205,6 +4212,7 @@ async function saveEditMeeting() {
 }
 
 async function posponeEditMeeting() {
+    if (!canManage()) { toast("Sin permisos para posponer reuniones", "bad"); return; }
     if (!editMeetingId) return;
     
     try {
@@ -4389,7 +4397,9 @@ async function renderReports() {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
+                aspectRatio: 2,
+                resizeDelay: 150,
                 cutout: '65%',
                 animation: {
                     animateScale: true,
@@ -4466,7 +4476,9 @@ async function renderReports() {
             },
             options: {
                 responsive: true,
-                maintainAspectRatio: false,
+                maintainAspectRatio: true,
+                aspectRatio: 2,
+                resizeDelay: 150,
                 animation: {
                     duration: 1500,
                     easing: 'easeOutQuart'


### PR DESCRIPTION
## Summary
- Restrict management actions and buttons to `supervisor_admin` and `jefe_terminal`
- Guard meeting edit and postpone flows with role checks
- Prevent charts from stretching by keeping aspect ratio and capping grid width

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d8a841690832dae2de439edb281a7